### PR TITLE
Refactoring + tolerance improvements on dfly_inf_der

### DIFF
--- a/src/Contractors.jl
+++ b/src/Contractors.jl
@@ -60,7 +60,7 @@ function preimage_monotonic(y, f::Function, x::Interval, (y1, y2) = (f(Interval(
 			# Interval Newton step on x -> f(x) - y
 			@debug "Step $i, Newton method:
 			- the interval $x, 
-			- the derivative $(f′(x)),
+			- the derivative $enc_der,
 			- the value at the midpoint $(f(x_mid))
 			- the value $(f(x))"
 
@@ -72,7 +72,7 @@ function preimage_monotonic(y, f::Function, x::Interval, (y1, y2) = (f(Interval(
 			# Krawczyk step on x -> f(x) - y
 			@debug "Step $i, Krawczyk method:
 			- the interval $x, 
-			- the derivative $(f′(x)),
+			- the derivative $enc_der,
 			- the value at the midpoint $(f(x_mid))
 			- the value $(f(x))"
 

--- a/src/Norms.jl
+++ b/src/Norms.jl
@@ -206,7 +206,7 @@ end
 
 function dfly(N1::Type{TotalVariation}, N2::Type{L1}, D::PwMap)
     if has_infinite_derivative_at_endpoints(D)
-        return dfly_inf_der(N1, N2, D, 10^-3)
+        return dfly_inf_der(N1, N2, D)
     end
     
     dist = max_distortion(D)


### PR DESCRIPTION
This started out as a refactoring of dfly_inf_der to improve type stability, but I ended up finding and removing a couple of minor oversight in the choice of `tol` (which was set to very small value, and this decreased performance) and in the selection of the optimal exponent i (which chose the best value not of `B/(1-A)` but of a similar value computed using just one of the summand of `B`). As a result, now dfly_inf_der selects `i=8` rather than `i=7` on Lorenz^3, and the computed bounds improve.

As a point for future, we should note that it might make sense to optimize something else instead; I suspect that using smaller values of `i` might improve the estimate even further: it is not only the value of `B/(1-A)` that counts, but powers of A appear also in other places in the two-grid bound, so it might be more convenient to reduce even more the value of A at the expense of B.