### PR TITLE
FastLorenz

### DIFF
--- a/examples/time_convergence_plot2.jl
+++ b/examples/time_convergence_plot2.jl
@@ -20,6 +20,14 @@ function get_experiment(prefix)
             Q = DiscretizedOperator(B, D)
             return B, D, Q    
         end
+    elseif prefix=="FastLorenz3"
+        f = n-> begin
+            D0 = FastLorenz()
+            D = D0 ∘ D0 ∘ D0
+            B = Ulam(n)
+            Q = DiscretizedOperator(B, D)
+            return B, D, Q    
+        end
     elseif prefix=="Lorenz2"
         f = n-> begin
             D0 = Lorenz()

--- a/src/Contractors.jl
+++ b/src/Contractors.jl
@@ -60,7 +60,7 @@ function preimage_monotonic(y, f::Function, x::Interval, (y1, y2) = (f(Interval(
 			# Interval Newton step on x -> f(x) - y
 			@debug "Step $i, Newton method:
 			- the interval $x, 
-			- the derivative $(f′(x)),
+			- the derivative $enc_der,
 			- the value at the midpoint $(f(x_mid))
 			- the value $(f(x))"
 
@@ -72,7 +72,7 @@ function preimage_monotonic(y, f::Function, x::Interval, (y1, y2) = (f(Interval(
 			# Krawczyk step on x -> f(x) - y
 			@debug "Step $i, Krawczyk method:
 			- the interval $x, 
-			- the derivative $(f′(x)),
+			- the derivative $enc_der,
 			- the value at the midpoint $(f(x_mid))
 			- the value $(f(x))"
 

--- a/src/Norms.jl
+++ b/src/Norms.jl
@@ -206,7 +206,7 @@ end
 
 function dfly(N1::Type{TotalVariation}, N2::Type{L1}, D::PwMap)
     if has_infinite_derivative_at_endpoints(D)
-        return dfly_inf_der(N1, N2, D, 10^-3)
+        return dfly_inf_der(N1, N2, D)
     end
     
     dist = max_distortion(D)

--- a/src/sample_dynamics.jl
+++ b/src/sample_dynamics.jl
@@ -23,6 +23,10 @@ function BZ()
     )
 end
 
+"""
+    D = Lorenz(θ=109/64, α=51/64)
+
+"""
 Lorenz(θ=109/64, α=51/64) = PwMap([x->θ*(0.5-x)^α, x->1-θ*(x-0.5)^α],
                     [@interval(0), @interval(0.5), @interval(1)],
                     [θ*(Interval(0.5))^α Interval(0.0);
@@ -32,8 +36,14 @@ Lorenz(θ=109/64, α=51/64) = PwMap([x->θ*(0.5-x)^α, x->1-θ*(x-0.5)^α],
 Faster replacement for interval power
 """
 fastpow(x, α) = iszero(x) ? x : exp(α * log(x))
+
+"""
+    D = FastLorenz(θ=109/64, α=51/64)
+
+Different implementation of the Lorenz map which uses exp(a*log(x)) rather than x^a for intervals x.
+This should be significantly faster but return slightly worse enclosures
+"""
 FastLorenz(θ=109/64, α=51/64) = PwMap([x->θ*fastpow(0.5-x, α), x->1-θ*fastpow(x-0.5, α)],
                     [@interval(0), @interval(0.5), @interval(1)],
                     [θ*(Interval(0.5))^α Interval(0.0);
                     Interval(1.0)  1-θ*(Interval(0.5))^α])
-

--- a/src/sample_dynamics.jl
+++ b/src/sample_dynamics.jl
@@ -1,4 +1,4 @@
-export BZ, Lorenz
+export BZ, Lorenz, FastLorenz
 
 function BZ()
     A_big = Interval{BigFloat}(BigFloat("0.5060735690368223513195993710530479569801417368282037493809901142182256388277772"))
@@ -24,6 +24,15 @@ function BZ()
 end
 
 Lorenz(θ=109/64, α=51/64) = PwMap([x->θ*(0.5-x)^α, x->1-θ*(x-0.5)^α],
+                    [@interval(0), @interval(0.5), @interval(1)],
+                    [θ*(Interval(0.5))^α Interval(0.0);
+                    Interval(1.0)  1-θ*(Interval(0.5))^α])
+
+"""
+Faster replacement for interval power
+"""
+fastpow(x, α) = iszero(x) ? x : exp(α * log(x))
+FastLorenz(θ=109/64, α=51/64) = PwMap([x->θ*fastpow(0.5-x, α), x->1-θ*fastpow(x-0.5, α)],
                     [@interval(0), @interval(0.5), @interval(1)],
                     [θ*(Interval(0.5))^α Interval(0.0);
                     Interval(1.0)  1-θ*(Interval(0.5))^α])


### PR DESCRIPTION
Various speed improvements to the Lorenz map, coming from:

* refactoring and improvements to the tolerances in `dfly_inf_der`.
* a new variant of `Lorenz()` that uses the faster `exp(a*log(x::Interval))` rather than `x::Interval^a`.

